### PR TITLE
bugfix in negPairs

### DIFF
--- a/utils/vgg_metric/getNegPairs.m
+++ b/utils/vgg_metric/getNegPairs.m
@@ -13,8 +13,8 @@ function neg_pairs = getNegPairs(personID, personList, numPairs)
         
         % select two different persons
         t = randperm(length(personList), 2);
-        personListIdx1 = t(1);
-        personListIdx2 = t(2);    
+        personListIdx1 = personList(t(1));
+        personListIdx2 = personList(t(2));      
         
         % All data indices of that person
         idxData1 = find(personID == personListIdx1);


### PR DESCRIPTION
works only if the labels in personList are [1 2 3 ...].
So using t(1) and t(2) works. t(..) is an index into personList, but here can also be used as an element of personList.

But if we have labels that are something like [-1 1 1 -1]
then obviously we need to have personList(t(1)) etc.