### PR TITLE
make sort order reliable

### DIFF
--- a/caffe/MVCNNDataLayer.py
+++ b/caffe/MVCNNDataLayer.py
@@ -24,7 +24,7 @@ class MVCNNDataLayer(caffe.Layer):
     self._channel_Size = layer_params['channel_size']
     self._phase = layer_params['phase']   # train or test
     self._name_to_top_map = {'data': 0, 'label': 1}
-    self._classList = next(os.walk(self._dataPath))[1]
+    self._classList = sorted(next(os.walk(self._dataPath))[1])
     self._modelList = []
     self._model2lable = {}
     self._train_iteration = 0	

--- a/caffe/MVCNNDataLayerPreTrain.py
+++ b/caffe/MVCNNDataLayerPreTrain.py
@@ -24,7 +24,7 @@ class MVCNNDataLayerPreTrain(caffe.Layer):
     self._channel_Size = layer_params['channel_size']
     self._phase = layer_params['phase']   # train or test
     self._name_to_top_map = {'data': 0, 'label': 1}
-    self._classList = next(os.walk(self._dataPath))[1]
+    self._classList = sorted(next(os.walk(self._dataPath))[1])
     self._modelList = []
     self._model2lable = {}
     self._train_iteration = 0	


### PR DESCRIPTION
The Python walk function relies on [listdir](https://www.tutorialspoint.com/python/os_listdir.htm).
The order of the result of this function is arbitrary.

> The list is in arbitrary order.

This results in wrong labels when testing the network.
With this fix we can assume a sorted order.